### PR TITLE
Feature size threshold

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipeline/cache/Configuration.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/Configuration.java
@@ -1,13 +1,18 @@
 package io.jenkins.plugins.pipeline.cache;
 
+import java.io.IOException;
 import java.io.Serializable;
 
+import hudson.util.FormValidation;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import hudson.Extension;
 import hudson.ExtensionList;
 import jenkins.model.GlobalConfiguration;
+import org.kohsuke.stapler.QueryParameter;
+
+import javax.servlet.ServletException;
 
 /**
  * Pipeline cache configuration.
@@ -23,6 +28,7 @@ public class Configuration extends GlobalConfiguration implements Serializable {
     private String bucket;
     private String region;
     private String endpoint;
+    private long sizeThresholdMb; // stored in MB
 
     public Configuration() {
         load();
@@ -82,4 +88,25 @@ public class Configuration extends GlobalConfiguration implements Serializable {
         save();
     }
 
+    public long getSizeThresholdMb() {
+        return sizeThresholdMb;
+    }
+
+    /**
+     * @param sizeThresholdMb Storage size threshold in megabytes (1e6 bytes)
+     */
+    @DataBoundSetter
+    public void setSizeThresholdMb(long sizeThresholdMb) {
+        this.sizeThresholdMb = sizeThresholdMb;
+        save();
+    }
+
+    public FormValidation doCheckSizeThresholdMb(@QueryParameter String value) throws IOException, ServletException {
+        try {
+            Integer.parseInt(value);
+            return FormValidation.ok();
+        } catch (NumberFormatException e) {
+            return FormValidation.error("Not a number");
+        }
+    }
 }

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/agent/AbstractMasterToAgentS3Callable.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/agent/AbstractMasterToAgentS3Callable.java
@@ -30,7 +30,7 @@ public abstract class AbstractMasterToAgentS3Callable extends MasterToSlaveFileC
     /**
      * Provides a {@link AmazonS3} instance which can used on the agent directly.
      */
-    AmazonS3 s3() {
+    public AmazonS3 s3() {
         if (client == null) {
             synchronized (this) {
                 if (client == null) {

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/agent/BackupCallable.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/agent/BackupCallable.java
@@ -4,7 +4,12 @@ import static java.lang.String.format;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
 
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 import hudson.FilePath;
 import hudson.remoting.VirtualChannel;
 import io.jenkins.plugins.pipeline.cache.Configuration;
@@ -14,6 +19,7 @@ import io.jenkins.plugins.pipeline.cache.S3OutputStream;
  * Creates a tar archive of a given {@link FilePath} and uploads it to S3.
  */
 public class BackupCallable extends AbstractMasterToAgentS3Callable {
+    public static final long MB_TO_BYTES = 1000000;
     private final String key;
 
     public BackupCallable(Configuration config, String key) {
@@ -33,10 +39,62 @@ public class BackupCallable extends AbstractMasterToAgentS3Callable {
             new FilePath(f).tar(out, "**/*");
         }
 
-        return new ResultBuilder()
+        ObjectMetadata uploadedObjectMetadata = s3().getObjectMetadata(config.getBucket(), key);
+
+        ResultBuilder result = new ResultBuilder();
+        if (uploadedObjectMetadata.getContentLength() > config.getSizeThresholdMb() * MB_TO_BYTES) {
+            result.withInfo("WARNING: cache is larger than configured size threshold," +
+                    " at least one object is always cached despite that");
+        }
+        ResultBuilder resultBuilder = checkSizeThreshold(result, config.getBucket(), config.getSizeThresholdMb());
+
+        return resultBuilder
                 .withInfo("Cache saved successfully")
                 .withInfo("Cache saved with key: " + key)
-                .withInfo(format("Cache Size: %s B", s3().getObjectMetadata(config.getBucket(), key).getContentLength()))
+                .withInfo(format("Cache size: %s B", uploadedObjectMetadata.getContentLength()))
                 .build();
+    }
+
+    public ResultBuilder checkSizeThreshold(ResultBuilder result, String bucket, long sizeThresholdMb) {
+        long sizeThresholdBytes = sizeThresholdMb * 1000000;
+        if (sizeThresholdMb <= 0) {
+            return result.withInfo("Size threshold is less equal 0, will not delete any old objects");
+        }
+        ArrayList<S3ObjectSummary> s3ObjectSummaries = getS3ObjectSummaries(bucket);
+        if (s3ObjectSummaries.isEmpty()) {
+            // this should not happen though as @checkSizeThreshold is called after storing an object
+            return result.withInfo("Cache is empty");
+        }
+
+        deleteOldObjects(result, s3ObjectSummaries, bucket, sizeThresholdBytes);
+        return result;
+    }
+
+    private void deleteOldObjects(ResultBuilder result, ArrayList<S3ObjectSummary> s3ObjectSummaries, String bucket, long sizeThresholdBytes) {
+        long bytesTotal = s3ObjectSummaries.stream().map(S3ObjectSummary::getSize).reduce(0L, Long::sum);
+        if (bytesTotal > sizeThresholdBytes) {
+            // sort to select oldest data
+            s3ObjectSummaries.sort(Comparator.comparing(S3ObjectSummary::getLastModified));
+            // refactor the following with stream().takeWhile() for Java 9+
+            int deleteUpToIdx = 0;
+            long toRemove = bytesTotal - sizeThresholdBytes;
+            for (; deleteUpToIdx < s3ObjectSummaries.size() - 1 && toRemove > 0; deleteUpToIdx++) {
+                toRemove -= s3ObjectSummaries.get(deleteUpToIdx).getSize();
+                // remove the oldest objects to fit in with new object
+                s3().deleteObject(bucket, s3ObjectSummaries.get(deleteUpToIdx).getKey());
+            }
+            result.withInfo("Cache storage exceeded size threshold, removed " + deleteUpToIdx + " item(s)");
+        }
+    }
+
+    private ArrayList<S3ObjectSummary> getS3ObjectSummaries(String bucket) {
+        ObjectListing objectListing = s3().listObjects(bucket);
+        ArrayList<S3ObjectSummary> s3ObjectSummaries = new ArrayList<>(objectListing.getObjectSummaries());
+        // handle pagination of objectListings
+        while (objectListing.isTruncated()) {
+            s3ObjectSummaries.addAll(objectListing.getObjectSummaries());
+            objectListing = s3().listNextBatchOfObjects(objectListing);
+        }
+        return s3ObjectSummaries;
     }
 }

--- a/src/main/resources/io/jenkins/plugins/pipeline/cache/Configuration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/pipeline/cache/Configuration/config.jelly
@@ -21,5 +21,9 @@
         <f:entry title="${%Endpoint}" field="endpoint">
             <f:textbox default="https://s3.amazonaws.com" />
         </f:entry>
+
+        <f:entry title="${%Bucket size threshold (MB)}" field="sizeThresholdMb">
+            <f:textbox default="5000" />
+        </f:entry>
     </f:section>
 </j:jelly>

--- a/src/test/java/io/jenkins/plugins/pipeline/cache/CacheStepSizeThresholdTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/cache/CacheStepSizeThresholdTest.java
@@ -7,17 +7,11 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import io.jenkins.plugins.pipeline.cache.agent.AbstractMasterToAgentS3Callable;
 import io.jenkins.plugins.pipeline.cache.agent.BackupCallable;
-import org.apache.commons.io.FileUtils;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Objects;
 import java.util.UUID;
 
 /**

--- a/src/test/java/io/jenkins/plugins/pipeline/cache/CacheStepSizeThresholdTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/cache/CacheStepSizeThresholdTest.java
@@ -1,0 +1,132 @@
+package io.jenkins.plugins.pipeline.cache;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.jenkins.plugins.pipeline.cache.agent.AbstractMasterToAgentS3Callable;
+import io.jenkins.plugins.pipeline.cache.agent.BackupCallable;
+import org.apache.commons.io.FileUtils;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Integration test with Jenkins and MinIO.
+ */
+public class CacheStepSizeThresholdTest {
+
+    @ClassRule
+    public static MinioContainer minio = new MinioContainer();
+
+    @ClassRule
+    public static MinioMcContainer mc = new MinioMcContainer(minio);
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private String bucket;
+    private AmazonS3 client = null;
+    private BackupCallable backupCallable;
+
+
+    @Before
+    public void setup() throws IOException, InterruptedException {
+        bucket = UUID.randomUUID().toString();
+        mc.createBucket(bucket);
+        String username = minio.accessKey();
+        String password = minio.secretKey();
+        String region = "us-west-1";
+        String endpoint = minio.getExternalAddress();
+        client = AmazonS3ClientBuilder
+                .standard()
+                .withPathStyleAccessEnabled(true)
+                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(username, password)))
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
+                .build();
+
+        backupCallable = Mockito.spy(new BackupCallable(null, null));
+        Mockito.doReturn(client).when(backupCallable).s3();
+    }
+
+    @After
+    public void shutDown() {
+        if (client != null) {
+            client.shutdown();
+            client = null;
+        }
+    }
+
+    @Test
+    public void testDoesntDeleteBelowThreshold() throws Exception {
+        // GIVEN
+        AbstractMasterToAgentS3Callable.ResultBuilder resultBuilder = new AbstractMasterToAgentS3Callable.ResultBuilder();
+
+        for (int i = 0; i < 10; i++) {
+            // GIVEN
+            mc.createObject(bucket, "asdf" + i, "asdf");
+
+            // WHEN
+            backupCallable.checkSizeThreshold(resultBuilder, bucket, 1);
+
+            for (int j = 0; j <= i; j++) {
+                // THEN
+                assert client.doesObjectExist(bucket, "asdf" + i);
+
+            }
+        }
+    }
+
+    @Test
+    public void testDeleteBelowThreshold() throws Exception {
+        // GIVEN
+        AbstractMasterToAgentS3Callable.ResultBuilder resultBuilder = new AbstractMasterToAgentS3Callable.ResultBuilder();
+        mc.createObject(bucket, "asdf1", 2);
+
+        // WHEN
+        backupCallable.checkSizeThreshold(resultBuilder, bucket, 1);
+
+        // THEN
+        assert client.doesObjectExist(bucket, "asdf1");
+
+        // GIVEN
+        mc.createObject(bucket, "asdf2", 2);
+
+        // WHEN
+        backupCallable.checkSizeThreshold(resultBuilder, bucket, 1);
+
+        // THEN
+        assert !client.doesObjectExist(bucket, "asdf1");
+        assert client.doesObjectExist(bucket, "asdf2");
+    }
+
+    @Test
+    public void testThresholdZero() throws Exception {
+        // GIVEN
+        mc.createObject(bucket, "asdf1", 1);
+        mc.createObject(bucket, "asdf2", 1);
+        mc.createObject(bucket, "asdf3", 1);
+        mc.createObject(bucket, "asdf4", 1);
+
+        AbstractMasterToAgentS3Callable.ResultBuilder resultBuilder = new AbstractMasterToAgentS3Callable.ResultBuilder();
+
+        // WHEN
+        backupCallable.checkSizeThreshold(resultBuilder, bucket, 0);
+
+        // THEN
+        assert client.doesObjectExist(bucket, "asdf1");
+        assert client.doesObjectExist(bucket, "asdf2");
+        assert client.doesObjectExist(bucket, "asdf3");
+        assert client.doesObjectExist(bucket, "asdf4");
+    }
+
+}

--- a/src/test/java/io/jenkins/plugins/pipeline/cache/CacheStepTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/cache/CacheStepTest.java
@@ -92,4 +92,75 @@ public class CacheStepTest {
         j.assertLogContains("Cache already exists (bla-foo-3cd7a0db76ff9dca48979e24c39b408c), not saving cache.", b);
     }
 
+    @Test
+    public void testSizeThreshold() throws Exception {
+        // GIVEN
+        Configuration.get().setUsername(minio.accessKey());
+        Configuration.get().setPassword(minio.secretKey());
+        Configuration.get().setBucket(bucket);
+        Configuration.get().setRegion("us-west-1");
+        Configuration.get().setEndpoint(minio.getExternalAddress());
+        Configuration.get().setSizeThresholdMb(1);
+
+        // GIVEN
+        File file = folder.newFile();
+        FileUtils.writeStringToFile(file, "some test data", StandardCharsets.UTF_8);
+
+        // WHEN
+        WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node {\n" +
+                "  sh 'echo bla > pom.xml'\n" +
+                "  sh 'dd if=/dev/urandom of="+file.getAbsolutePath()+" bs=1048576 count=2'\n" +
+                "  cache(folder: '"+folder.getRoot().getAbsolutePath()+"', hashFiles: '**/pom.xml', type: 'bla-foo') {\n" +
+                "    sh 'ls -alth'\n" +
+                "    sh 'ls -alth "+folder.getRoot().getAbsolutePath()+"'\n" +
+                "  }\n" +
+                "}", true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(b);
+
+        // THEN
+        j.assertBuildStatusSuccess(b);
+        j.assertLogContains("Cache size: 209", b); // how to match with regex for whole line?
+        j.assertLogContains("WARNING: cache is larger than configured size threshold", b);
+
+        // WHEN
+        p.setDefinition(new CpsFlowDefinition("node {\n" +
+                "  sh 'rm "+file.getAbsolutePath()+"'\n" +
+                "  cache(folder: '"+folder.getRoot().getAbsolutePath()+"', hashFiles: '**/pom.xml', type: 'bla-foo') {\n" +
+                "    sh 'ls -alth'\n" +
+                "    sh 'ls -alth "+folder.getRoot().getAbsolutePath()+"'\n" +
+                "  }\n" +
+                "}", true));
+        b = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(b);
+
+        // THEN
+        j.assertBuildStatusSuccess(b);
+        j.assertLogContains("Cache restored from key: bla-foo-3cd7a0db76ff9dca48979e24c39b408c", b);
+        j.assertLogContains("total 2.1M", b);
+        j.assertLogContains("Cache already exists (bla-foo-3cd7a0db76ff9dca48979e24c39b408c), not saving cache.", b);
+
+        // GIVEN
+        File pomfile = folder.newFile("pom.xml");
+        FileUtils.writeStringToFile(pomfile, "other", StandardCharsets.UTF_8);
+
+        // WHEN
+        p.setDefinition(new CpsFlowDefinition("node {\n" +
+                "  sh 'echo other > pom.xml'\n" +
+                "  sh 'dd if=/dev/urandom of="+file.getAbsolutePath()+" bs=1048576 count=1'\n" +
+                "  cache(folder: '"+folder.getRoot().getAbsolutePath()+"', hashFiles: '**/pom.xml', type: 'other-foo') {\n" +
+                "    sh 'ls -alth'\n" +
+                "    sh 'ls -alth "+folder.getRoot().getAbsolutePath()+"'\n" +
+                "  }\n" +
+                "}", true));
+        b = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(b);
+
+        // THEN
+        j.assertBuildStatusSuccess(b);
+        j.assertLogContains("Cache not restored (no such key found)", b);
+        j.assertLogContains("total 1.1M", b);
+        j.assertLogContains("Cache storage exceeded size threshold, removed 1 item(s)", b);
+    }
 }

--- a/src/test/java/io/jenkins/plugins/pipeline/cache/ConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/cache/ConfigurationTest.java
@@ -23,18 +23,21 @@ public class ConfigurationTest {
             assertNull("should be empty initially", Configuration.get().getBucket());
             assertNull("should be empty initially", Configuration.get().getRegion());
             assertNull("should be empty initially", Configuration.get().getEndpoint());
+            assertEquals(0, Configuration.get().getSizeThresholdMb());
 
             setTextInput(r,"username", "alice");
             setTextInput(r,"password", "secret");
             setTextInput(r,"bucket", "blue");
             setTextInput(r,"region", "dc1");
             setTextInput(r,"endpoint", "http://localhost:9000");
+            setLongInput(r,"sizeThresholdMb", 777);
 
             assertEquals("should be editable", "alice", Configuration.get().getUsername());
             assertEquals("should be editable", "secret", Configuration.get().getPassword());
             assertEquals("should be editable", "blue", Configuration.get().getBucket());
             assertEquals("should be editable", "dc1", Configuration.get().getRegion());
             assertEquals("should be editable", "http://localhost:9000", Configuration.get().getEndpoint());
+            assertEquals("should be editable", 777, Configuration.get().getSizeThresholdMb());
         });
         rr.then(r -> {
             assertEquals("should be still there after restart of Jenkins", "alice", Configuration.get().getUsername());
@@ -42,6 +45,7 @@ public class ConfigurationTest {
             assertEquals("should be still there after restart of Jenkins", "blue", Configuration.get().getBucket());
             assertEquals("should be still there after restart of Jenkins", "dc1", Configuration.get().getRegion());
             assertEquals("should be still there after restart of Jenkins", "http://localhost:9000", Configuration.get().getEndpoint());
+            assertEquals("should be still there after restart of Jenkins", 777, Configuration.get().getSizeThresholdMb());
         });
     }
 
@@ -49,6 +53,13 @@ public class ConfigurationTest {
         HtmlForm config = r.createWebClient().goTo("configure").getFormByName("config");
         HtmlInput input = config.getInputByName("_." + fieldName);
         input.setValueAttribute(value);
+        r.submit(config);
+    }
+
+    private void setLongInput(JenkinsRule r, String fieldName, long value) throws Exception {
+        HtmlForm config = r.createWebClient().goTo("configure").getFormByName("config");
+        HtmlInput input = config.getInputByName("_." + fieldName);
+        input.setValueAttribute(Long.toString(value));
         r.submit(config);
     }
 

--- a/src/test/java/io/jenkins/plugins/pipeline/cache/MinioMcContainer.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/cache/MinioMcContainer.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.pipeline.cache;
 
 import static java.lang.String.format;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 
@@ -55,6 +56,11 @@ public class MinioMcContainer extends GenericContainer<MinioMcContainer> {
 
     public void createObject(String bucket, String key, String content) throws IOException, InterruptedException {
         execSecure("echo -n \"%s\" | mc pipe test-minio/%s/%s", content, bucket, key);
+    }
+
+    public void createObject(String bucket, String key, int megabytes) throws IOException, InterruptedException {
+        execSecure("dd if=/dev/urandom of=tmp.rnd bs=1000000 count=%s", megabytes);
+        execSecure("mc cp tmp.rnd test-minio/%s/%s", bucket, key);
     }
 
     public void createObject(String bucket, String key) throws IOException, InterruptedException {


### PR DESCRIPTION
PR for issue #4 .

AC
**- there is a new configuration option which allows to specify the max size (soft limit)**
The configuration option is called "Bucket size threshold" and also has a validator that input is an integer. Units are in megabytes (MB, not MiB). When configured less equal 0 it doesn't delete any objects.

**- the limit defines the size when the plugin starts removing old backups**
New method checkSizeThreshold in BackupCallable takes care of that. After uploading cache, it checks size is less than threshold. If yes, it goes from oldest backups and removes them until the bucket is under the threshold again.

____
Screenshots from integration test:
![image](https://user-images.githubusercontent.com/26442779/135620015-f954a7a8-ff25-41f1-9a5b-63f68152d317.png)
![image](https://user-images.githubusercontent.com/26442779/135619974-e76b351b-c445-4b4e-8f7b-f4b79c9f55da.png)

![image](https://user-images.githubusercontent.com/26442779/135619889-8ba7fdef-2cc0-4261-b080-3521ec486e34.png)
![image](https://user-images.githubusercontent.com/26442779/135620118-4dfa5814-f141-4026-90ce-03b2f12657e6.png)
