### PR TITLE
store credentials more secure

### DIFF
--- a/src/main/java/io/jenkins/plugins/pipeline/cache/CacheConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/CacheConfiguration.java
@@ -9,6 +9,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 import hudson.Extension;
 import hudson.ExtensionList;
+import hudson.util.Secret;
 import io.jenkins.plugins.pipeline.cache.s3.CacheItemRepository;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
@@ -26,7 +27,7 @@ public class CacheConfiguration extends GlobalConfiguration implements Serializa
     private static final long serialVersionUID = 1L;
 
     private String username;
-    private String password;
+    private Secret password;
     private String bucket;
     private String region;
     private String endpoint;
@@ -50,12 +51,12 @@ public class CacheConfiguration extends GlobalConfiguration implements Serializa
         save();
     }
 
-    public String getPassword() {
+    public Secret getPassword() {
         return password;
     }
 
     @DataBoundSetter
-    public void setPassword(String password) {
+    public void setPassword(Secret password) {
         this.password = password;
         save();
     }

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/agent/AbstractMasterToAgentS3Callable.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/agent/AbstractMasterToAgentS3Callable.java
@@ -27,7 +27,7 @@ public abstract class AbstractMasterToAgentS3Callable extends MasterToSlaveFileC
             synchronized (this) {
                 cacheItemRepository = new CacheItemRepository(
                         config.getUsername(),
-                        config.getPassword(),
+                        config.getPassword().getPlainText(),
                         config.getRegion(),
                         config.getEndpoint(),
                         config.getBucket()

--- a/src/main/java/io/jenkins/plugins/pipeline/cache/cleanup/CacheCleanupLRUJob.java
+++ b/src/main/java/io/jenkins/plugins/pipeline/cache/cleanup/CacheCleanupLRUJob.java
@@ -42,7 +42,7 @@ public class CacheCleanupLRUJob extends AsyncPeriodicWork {
         // setup
         CacheItemRepository repo = new CacheItemRepository(
                 config.getUsername(),
-                config.getPassword(),
+                config.getPassword().getPlainText(),
                 config.getRegion(),
                 config.getEndpoint(),
                 config.getBucket()

--- a/src/test/java/io/jenkins/plugins/pipeline/cache/CacheStepTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/cache/CacheStepTest.java
@@ -15,6 +15,7 @@ import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import hudson.model.Result;
+import hudson.util.Secret;
 
 /**
  * Checks that the cache step works as expected in pipelines. Each test starts with an empty bucket and the cache is also registered to
@@ -47,7 +48,7 @@ public class CacheStepTest {
 
         // GIVEN
         CacheConfiguration.get().setUsername(minio.accessKey());
-        CacheConfiguration.get().setPassword(minio.secretKey());
+        CacheConfiguration.get().setPassword(Secret.fromString(minio.secretKey()));
         CacheConfiguration.get().setBucket(bucket);
         CacheConfiguration.get().setRegion("us-west-1");
         CacheConfiguration.get().setEndpoint(minio.getExternalAddress());

--- a/src/test/java/io/jenkins/plugins/pipeline/cache/ConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/cache/ConfigurationTest.java
@@ -37,7 +37,7 @@ public class ConfigurationTest {
 
             // THEN
             assertEquals("should be editable", "alice", CacheConfiguration.get().getUsername());
-            assertEquals("should be editable", "secret", CacheConfiguration.get().getPassword());
+            assertEquals("should be editable", "secret", CacheConfiguration.get().getPassword().getPlainText());
             assertEquals("should be editable", "blue", CacheConfiguration.get().getBucket());
             assertEquals("should be editable", "dc1", CacheConfiguration.get().getRegion());
             assertEquals("should be editable", "http://localhost:9000", CacheConfiguration.get().getEndpoint());
@@ -47,7 +47,7 @@ public class ConfigurationTest {
         rr.then(r -> {
             // THEN
             assertEquals("should be still there after restart of Jenkins", "alice", CacheConfiguration.get().getUsername());
-            assertEquals("should be still there after restart of Jenkins", "secret", CacheConfiguration.get().getPassword());
+            assertEquals("should be still there after restart of Jenkins", "secret", CacheConfiguration.get().getPassword().getPlainText());
             assertEquals("should be still there after restart of Jenkins", "blue", CacheConfiguration.get().getBucket());
             assertEquals("should be still there after restart of Jenkins", "dc1", CacheConfiguration.get().getRegion());
             assertEquals("should be still there after restart of Jenkins", "http://localhost:9000", CacheConfiguration.get().getEndpoint());


### PR DESCRIPTION
Fixes a security issue mentioned by @[darxriggs](https://github.com/darxriggs) where sensitive data is stored not correctly (see https://github.com/j3t/jenkins-pipeline-cache-plugin/commit/edd6612daedd9026edb7c481e8ab27ed598bbf30#r75306384). 