### PR TITLE
default excludes are disabled if a filter is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ If the job gets executed, the plugin tries to restore the maven repository from 
 
 Below you can find a complete list of the `cache` step parameters:
 
-| Name        | Required | Description | Default                   | Example |
-|-------------|----------|-------------|---------------------------|---------|
-| path        | x        | Path to the directory which we want to be cached (absolute or relative to the workspace) |  | `$HOME/.m2/repository` (caches the local maven repository) |
-| key         | x        | Identifier which is assigned to the cache. |  | `maven-4f98f59e877ecb84ff75ef0fab45bac5` |
-| restoreKeys |          | Additional keys which are used when the cache gets restored. The plugin tries to resolve them in the defined order (`key` first then the `restoreKeys`) and in case this was not successful then the latest key with the same prefix gets restored. |  | `['maven-', 'petclinic-']` (restores the latest cache where the key starts with `maven-` or `petclinic-` if the `key` not exists) |
-| filter      |          | Glob pattern applied to the `path` to filter the includes. | `**/*` includes all files | `**/*.xml` includes only XML files |
+| Name        | Required | Description                                                                                                                                                                                                                                         | Default                                                                                                    | Example                                                                                                                          |
+|-------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| path        | x        | Path to the directory which we want to be cached (absolute or relative to the workspace)                                                                                                                                                            |                                                                                                            | `$HOME/.m2/repository` - cache the local maven repository                                                                        |
+| key         | x        | Identifier which is assigned to the cache.                                                                                                                                                                                                          |                                                                                                            | `maven-4f98f59e877ecb84ff75ef0fab45bac5`                                                                                         |
+| restoreKeys |          | Additional keys which are used when the cache gets restored. The plugin tries to resolve them in the defined order (`key` first then the `restoreKeys`) and in case this was not successful then the latest key with the same prefix gets restored. |                                                                                                            | `['maven-', 'petclinic-']` - restore the latest cache where the key starts with `maven-` or `petclinic-` if the `key` not exists |
+| filter      |          | Glob pattern applied to the `path` to filter the includes.                                                                                                                                                                                          | Includes all files except [default excludes](https://ant.apache.org/manual/dirtasks.html#defaultexcludes). | `**/*` - includes all files, `**/*.xml` - includes only XML files                                                                |
 
 # Storage providers
 Any S3 compatible storage provider should work. MinIO is supported first class, because all the integration tests are executed against MinIO.
@@ -70,6 +70,7 @@ As a general advice, sensitive data or data which cannot be restored from somewh
 # Pitfalls
 * the `hashFiles` step expects a [Glob](https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob) pattern relative to the workspace as parameter
 * the `filter` parameter must be a [Glob](https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob) pattern relative to the `path`
+* if the `filter` parameter is not empty then the [default excludes](https://ant.apache.org/manual/dirtasks.html#defaultexcludes) are disabled as well
 * the cache gets not stored if the `key` already exists or the inner-step has been failed (e.g. unit-test failures)
 * existing files are replaced but not removed when the cache gets restored
 * the plugin creates a tar archive from the path and stores it as an S3 object

--- a/src/test/java/io/jenkins/plugins/pipeline/cache/CacheStepTest.java
+++ b/src/test/java/io/jenkins/plugins/pipeline/cache/CacheStepTest.java
@@ -369,6 +369,39 @@ public class CacheStepTest {
         j.assertBuildStatusSuccess(b);
     }
 
+    @Test
+    public void testDefaultExcludes() throws Exception {
+        // GIVEN
+        WorkflowJob p = createWorkflow("node {\n" +
+                "  sh 'mkdir -p a/.git && touch a/.git/config'\n" +
+                "  cache(path: 'a', key: 'a') {}\n" +
+                "  cache(path: 'b', key: 'a') {}\n" +
+                "  assert !fileExists('b/.git/config')\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun b = executeWorkflow(p);
+
+        // THEN
+        j.assertBuildStatusSuccess(b);
+    }
+
+    @Test
+    public void testDefaultExcludesIgnoredWhenFilterIsActive() throws Exception {
+        // GIVEN
+        WorkflowJob p = createWorkflow("node {\n" +
+                "  sh 'mkdir -p a/.git && touch a/.git/config'\n" +
+                "  cache(path: 'a', key: 'a', filter: '**/*') {}\n" +
+                "  cache(path: 'b', key: 'a') {}\n" +
+                "  assert fileExists('b/.git/config')\n" +
+                "}");
+
+        // WHEN
+        WorkflowRun b = executeWorkflow(p);
+
+        // THEN
+        j.assertBuildStatusSuccess(b);
+    }
 
     private WorkflowJob createWorkflow(String script) throws IOException {
         WorkflowJob p = j.createProject(WorkflowJob.class);


### PR DESCRIPTION
This PR takes care of the [default excludes](https://ant.apache.org/manual/dirtasks.html#defaultexcludes).

Changes:
They are still active by default but now they are disabled if filter is defined.